### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,7 @@
 name: .NET
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TownSuite/TownSuite.Web.SSV3Adapter/security/code-scanning/5](https://github.com/TownSuite/TownSuite.Web.SSV3Adapter/security/code-scanning/5)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal scopes required by the workflow. For read-only operations like checkout and artifact upload/download, `contents: read` is sufficient. Since the workflow posts a sticky pull-request comment, it additionally needs `pull-requests: write`. We do not see any need for broader write scopes (e.g., `contents: write`, `issues: write`, `checks: write`).

The best fix here is to add a `permissions:` block at the workflow root (right after `name:` and before `on:`), so it applies to the entire workflow and its single `build` job. The block should set `contents: read` and `pull-requests: write`. This does not change existing functionality: all existing steps will still be able to run, and the PR comment action will have the necessary permission to create/update comments on pull requests.

Concretely, in `.github/workflows/dotnet.yml`, insert:

```yaml
permissions:
  contents: read
  pull-requests: write
```

between line 1 (`name: .NET`) and line 3 (`on:`), shifting the subsequent lines down by two. No additional methods, imports, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
