### PR TITLE
Added cancellation from request aborted support to services

### DIFF
--- a/TownSuite.Web.Example/ServiceStackExample/ExampleAsyncClass.cs
+++ b/TownSuite.Web.Example/ServiceStackExample/ExampleAsyncClass.cs
@@ -1,0 +1,8 @@
+﻿namespace TownSuite.Web.Example.ServiceStackExample
+{
+    public class ExampleAsyncClass
+    {
+        public string? Message { get; set; }
+        public int DelayMilliseconds { get; set; } = 100;
+    }
+}

--- a/TownSuite.Web.Example/ServiceStackExample/ExampleAsyncClassResponse.cs
+++ b/TownSuite.Web.Example/ServiceStackExample/ExampleAsyncClassResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace TownSuite.Web.Example.ServiceStackExample
+{
+    public class ExampleAsyncClassResponse
+    {
+        public bool DidCancelWithResponse { get; set; } = false;
+    }
+}

--- a/TownSuite.Web.Example/ServiceStackExample/ExampleAsyncClassService.cs
+++ b/TownSuite.Web.Example/ServiceStackExample/ExampleAsyncClassService.cs
@@ -1,0 +1,35 @@
+﻿namespace TownSuite.Web.Example.ServiceStackExample
+{
+    [Example]
+    public class ExampleAsyncClassService: BaseServiceExample
+    {
+        public async Task<ExampleAsyncClassResponse> Any(ExampleAsyncClass request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(request.Message))
+                {
+                    throw new Exception("Please Provide a Message.");
+                }
+                // demonstrate that it works with async methods
+                await Task.Delay(request?.DelayMilliseconds ?? 100, cancellationToken);
+            } catch (TaskCanceledException)
+            {
+                return new ExampleAsyncClassResponse()
+                {
+                    DidCancelWithResponse = true
+                };
+            }
+
+            return new ExampleAsyncClassResponse
+            {
+                DidCancelWithResponse = false
+            };
+        }
+
+        public void SomeOtherExampleMethod()
+        {
+            Console.WriteLine("SomeOtherExampleMethod called");
+        }
+    }
+}

--- a/TownSuite.Web.SSV3Adapter/ServiceStackFacade.cs
+++ b/TownSuite.Web.SSV3Adapter/ServiceStackFacade.cs
@@ -29,7 +29,8 @@ internal class ServiceStackAdapter
     public async Task<(int statusCode, string? json)> Post(
         string path,
         string value,
-        string method)
+        string method,
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -59,7 +60,7 @@ internal class ServiceStackAdapter
             var request = JsonConvert.DeserializeObject(value ?? "", serviceInfo.Value.DtoType,
                 _options.SerializerSettings);
 
-            var results = await CreateAndInvokeService(serviceInfo.Value, request);
+            var results = await CreateAndInvokeService(serviceInfo.Value, request, cancellationToken);
             _prom?.EndRequest(results.statusCode.ToString(),
                 method,
                 name, serviceInfo.Value.Method.Name);
@@ -78,7 +79,7 @@ internal class ServiceStackAdapter
     }
 
     private async Task<(int statusCode, string? json)> CreateAndInvokeService((Type Service, MethodInfo Method,
-        Type DtoType) serviceInfo, object? request)
+        Type DtoType) serviceInfo, object? request, CancellationToken cancellationToken)
     {
         var secureAttribute = await _ssHelper.GetAttributeAsync<IExecutableAttribute>(serviceInfo.Service);
         if (secureAttribute != null)
@@ -104,8 +105,25 @@ internal class ServiceStackAdapter
         if (_options.CustomCallBack != null)
             await _options.CustomCallBack((CustomCall.ServiceInstantiated, instance, request));
 
-
-        object[] arguments = { request };
+        var parameterList = serviceInfo.Method.GetParameters();
+        var requestAdded = false;
+        var arguments = new List<object?>();
+        foreach (var parameter in parameterList)
+        {
+            if (parameter.ParameterType == typeof(CancellationToken))
+            {
+                arguments.Add(cancellationToken);
+            }
+            else
+            {
+                if (requestAdded)
+                {
+                    throw new ArgumentException("Too many parameters in controller.");
+                }
+                arguments.Add(request);
+                requestAdded = true;
+            }
+        }
 
         string output;
         Task t = null;
@@ -113,14 +131,14 @@ internal class ServiceStackAdapter
         {
             if (SsHelper.IsAsyncMethod(serviceInfo.Method))
             {
-                t = serviceInfo.Method.Invoke(instance, arguments) as Task;
+                t = serviceInfo.Method.Invoke(instance, arguments.ToArray()) as Task;
                 await t.ConfigureAwait(false);
                 var response = t.GetType().GetProperty("Result").GetValue(t);
                 output = JsonConvert.SerializeObject(response);
                 return (200, output);
             }
 
-            var val = await Task.FromResult(serviceInfo.Method.Invoke(instance, arguments));
+            var val = await Task.FromResult(serviceInfo.Method.Invoke(instance, arguments.ToArray()));
             t = Task.FromResult(val);
             output = JsonConvert.SerializeObject(val);
             return (200, output);

--- a/TownSuite.Web.SSV3Adapter/ServiceStackV3FacadeRouteExtensions.cs
+++ b/TownSuite.Web.SSV3Adapter/ServiceStackV3FacadeRouteExtensions.cs
@@ -33,11 +33,11 @@ public static class ServiceStackV3AdapterRouteExtensions
                 var Adapter = new ServiceStackAdapter(options,
                     serviceProvider,
                     prom);
-                var results = await Adapter.Post(path, value, method);
+                var results = await Adapter.Post(path, value, method, context.RequestAborted);
 
                 context.Response.StatusCode = results.statusCode;
                 context.Response.ContentType = "application/json";
-                await context.Response.WriteAsync(results.json ?? "");
+                await context.Response.WriteAsync(results.json ?? "", context.RequestAborted);
             });
         });
 

--- a/TownSuite.Web.SSV3Adapter/SsHelper.cs
+++ b/TownSuite.Web.SSV3Adapter/SsHelper.cs
@@ -191,7 +191,7 @@ internal class SsHelper
         foreach (var mi in methods)
         {
             var parameters = mi.GetParameters();
-            if (parameters.Length != 1) continue;
+            if (parameters.Length <= 0 || parameters.Length > 2) continue;
 
             var parameterString = parameters.FirstOrDefault().ParameterType.ToString();
             var individualParameter = parameterString?.Split('.').LastOrDefault();
@@ -270,10 +270,12 @@ internal class SsHelper
     {
         foreach (var mi in serviceType.GetMethods(BindingFlags.Public | BindingFlags.Instance).OrderBy(p => p.Name))
         {
-            if (mi.IsGenericMethod || mi.GetParameters().Length != 1)
+            var parameters = mi.GetParameters();
+
+            if (mi.IsGenericMethod || parameters.Length <= 0 || parameters.Length > 2)
                 continue;
 
-            var paramType = mi.GetParameters()[0].ParameterType;
+            var paramType = parameters[0].ParameterType;
             if (paramType.IsValueType || paramType == typeof(string))
                 continue;
 

--- a/TownSuite.Web.Tests/ExampleServiceTest.cs
+++ b/TownSuite.Web.Tests/ExampleServiceTest.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
+using TownSuite.Web.Example.ServiceStackExample;
 using TownSuite.Web.SSV3Adapter;
 
 namespace TownSuite.Web.Tests;
@@ -37,6 +39,51 @@ public class ExampleServiceTest
         var results = await adapter.Post(path, value, "any");
 
         Assert.That(results.json, Is.EqualTo("{\"FirstName\":\"Hello\",\"LastName\":\"World\"}"));
+        Assert.That(results.statusCode == 200);
+    }
+
+    [Test]
+    public async Task HappyPathTest_cancellation_tokens()
+    {
+        var options = Settings.GetSettings();
+        var serviceProvider = Settings.GetServiceProvider();
+        var cancelSource = new CancellationTokenSource();
+
+        var path = "https://localhost/ExampleAsyncClass";
+
+        var value = JsonConvert.SerializeObject(new ExampleAsyncClass()
+        {
+            Message = "Hello World"
+        });
+
+        var adapter = new ServiceStackAdapter(options, serviceProvider);
+        var results = await adapter.Post(path, value, "any", cancelSource.Token);
+
+        Assert.That(results.json, Is.EqualTo("{\"DidCancelWithResponse\":false}"));
+        Assert.That(results.statusCode == 200);
+    }
+
+    [Test]
+    public async Task Should_allow_handling_cancellation_tokens_in_controller()
+    {
+        var options = Settings.GetSettings();
+        var serviceProvider = Settings.GetServiceProvider();
+        var cancelSource = new CancellationTokenSource();
+
+        var path = "https://localhost/ExampleAsyncClass";
+
+        var value = JsonConvert.SerializeObject(new ExampleAsyncClass()
+        {
+            Message = "Hello World",
+            DelayMilliseconds = 100
+        });
+
+        var adapter = new ServiceStackAdapter(options, serviceProvider);
+        var task = adapter.Post(path, value, "any", cancelSource.Token);
+        cancelSource.Cancel();
+        var results = await task;
+
+        Assert.That(results.json, Is.EqualTo("{\"DidCancelWithResponse\":true}"));
         Assert.That(results.statusCode == 200);
     }
 


### PR DESCRIPTION
Using HttpContext.RequestAborted we can replicate Asp.NET's ability to cancel a request early using a Cancellation Token in the parameter.

This will be important for allowing Web Services to cancel AI requests when needed.

With this change it could be easy to support zero parameter requests in the far future.

Current quirks / limitations:
- This changes the assembly search to look for two parameter classes as well. If this hurts performance then further improvements can be made.
- The Cancellation Token must be the second parameter. If it is the first, it will not be found even as a "CancellationToken" endpoint.

Related issue: https://github.com/TownSuite/TownSuite.IssueTracker/issues/13737