### PR TITLE
Enhance security and configuration for local development 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to ".env" (which is git-ignored) and set a local-only value.
+# Used by docker-compose for the local MSSQL test container and the example app's
+# ConnectionStrings__TestDb. This is a throwaway local development credential — do NOT
+# reuse a real password and do NOT commit the populated .env file.
+SQL_SA_PASSWORD=ChangeMe_LocalDev123&

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@ name: .NET
 permissions:
   contents: read
   pull-requests: write
+  issues: write
+  checks: write
 
 on:
   push:
@@ -26,7 +28,10 @@ jobs:
         run: dotnet test -c Release TownSuite.Web.SSV3Adapter.sln --verbosity normal --collect:"XPlat Code Coverage" --logger:"trx" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile='**/TownSuite.Web.Example/**/*.cs'
       - name: Test Report
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        if: success() || failure() # run this step even if previous step failed
+        # Run even if tests fail, but never let reporting (which needs a writable token,
+        # unavailable on fork PRs) fail the build.
+        if: success() || failure()
+        continue-on-error: true
         with:
           name: unit tests
           path: "**/TestResults/*.trx"
@@ -47,7 +52,10 @@ jobs:
         run: cat **code-coverage-results.md** >> $GITHUB_STEP_SUMMARY
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 #v2.9.4
-        if: github.event_name == 'pull_request'
+        # Only for same-repo PRs: PRs from forks get a read-only GITHUB_TOKEN that cannot post
+        # comments ("Resource not accessible by integration"). Coverage is still in the job summary.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         with:
           recreate: true
           path: code-coverage-results.md

--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,5 @@ ASALocalRun/
 
 # Local History for Visual Studio
 .localhistory/
+# Local secrets / docker-compose env (never commit)
+.env

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-      <AssemblyVersion>26.0.1</AssemblyVersion>
-      <FileVersion>26.0.1</FileVersion>
-      <Version>26.0.1</Version>
+      <AssemblyVersion>26.1.0</AssemblyVersion>
+      <FileVersion>26.1.0</FileVersion>
+      <Version>26.1.0</Version>
       <Deterministic>true</Deterministic>
       <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
       <Company>TownSuite Municipal Software Inc.</Company>

--- a/TownSuite.Web.Example/AllPropertiesResolver.cs
+++ b/TownSuite.Web.Example/AllPropertiesResolver.cs
@@ -7,7 +7,16 @@ public class AllPropertiesResolver : DefaultContractResolver
     protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
     {
         var property = base.CreateProperty(member, memberSerialization);
-        property.Ignored = false;
+
+        if (property.Ignored)
+        {
+            // The member was explicitly excluded (e.g. [JsonIgnore]). Surface it for SS v3
+            // backwards-compatible output, but never let it be populated from request input -
+            // doing so reintroduces overposting / mass-assignment of server-controlled fields.
+            property.Ignored = false;
+            property.Writable = false;
+        }
+
         return property;
     }
 }

--- a/TownSuite.Web.Example/Dockerfile
+++ b/TownSuite.Web.Example/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["TownSuite.Web.Example/TownSuite.Web.Example.csproj", "TownSuite.Web.Example/"]
 COPY ["TownSuite.Web.SSV3Adapter/TownSuite.Web.SSV3Adapter.csproj", "TownSuite.Web.SSV3Adapter/"]

--- a/TownSuite.Web.Example/Program.cs
+++ b/TownSuite.Web.Example/Program.cs
@@ -147,20 +147,26 @@ app.UseServiceStackV3Adapter(new ServiceStackV3AdapterOptions(
     }, serviceProvider: simpleInjectorContainer
 );
 
-app.UseServiceStackV3AdapterSwagger(new ServiceStackV3AdapterOptions(
-    serviceTypes: new Type[]
-    {
-        typeof(BaseServiceExample),
-        typeof(InterfaceServiceExample)
-    })
+// The generated swagger document enumerates the full internal service/DTO surface and is served
+// unauthenticated, so only expose it outside of production. Protect it with an authorization
+// policy or network restriction if it must be available in production.
+if (app.Environment.IsDevelopment())
 {
-    SwaggerPath = "/swag/swagger.json",
-    RoutePath = "/example/service/json/syncreply",
-    SearchAssemblies = new Assembly[]
+    app.UseServiceStackV3AdapterSwagger(new ServiceStackV3AdapterOptions(
+        serviceTypes: new Type[]
+        {
+            typeof(BaseServiceExample),
+            typeof(InterfaceServiceExample)
+        })
     {
-        Assembly.Load("TownSuite.Web.Example")
-    }
-});
+        SwaggerPath = "/swag/swagger.json",
+        RoutePath = "/example/service/json/syncreply",
+        SearchAssemblies = new Assembly[]
+        {
+            Assembly.Load("TownSuite.Web.Example")
+        }
+    });
+}
 
 
 app.MapControllers();

--- a/TownSuite.Web.Example/ServiceStackExample/ExampleDataProfilingService.cs
+++ b/TownSuite.Web.Example/ServiceStackExample/ExampleDataProfilingService.cs
@@ -24,7 +24,8 @@ public class ExampleDataProfilingService : BaseServiceExample
             using var cn = new SqlConnection(cnStr);
 
             await cn.OpenAsync();
-            var data = await cn.QueryAsync("SELECT test_column, test_column2 FROM test_table");
+            // Result intentionally not captured; this only demonstrates issuing a DB call.
+            await cn.QueryAsync("SELECT test_column, test_column2 FROM test_table");
         }
 
         return new ExampleDataProfilingResponse

--- a/TownSuite.Web.Example/ServiceStackExample/ExampleDataProfilingService.cs
+++ b/TownSuite.Web.Example/ServiceStackExample/ExampleDataProfilingService.cs
@@ -17,11 +17,15 @@ public class ExampleDataProfilingService : BaseServiceExample
     {
         var cnStr = _configuration.GetConnectionString("TestDb");
 
-        // using var cn = new System.Data.SqlClient.SqlConnection(cnStr);
-        using var cn = new SqlConnection(cnStr);
+        // The connection string is supplied via environment / user-secrets (no secret is committed).
+        // Skip the DB call when it is not configured so the example still runs without a database.
+        if (!string.IsNullOrWhiteSpace(cnStr))
+        {
+            using var cn = new SqlConnection(cnStr);
 
-        await cn.OpenAsync();
-        var data = await cn.QueryAsync("SELECT test_column, test_column2 FROM test_table");
+            await cn.OpenAsync();
+            var data = await cn.QueryAsync("SELECT test_column, test_column2 FROM test_table");
+        }
 
         return new ExampleDataProfilingResponse
         {

--- a/TownSuite.Web.Example/TownSuite.Web.Example.csproj
+++ b/TownSuite.Web.Example/TownSuite.Web.Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
@@ -10,13 +10,18 @@
 
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.1.35" />
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3" />
         <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.5.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
         <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
         <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.5.0" />
+        <!-- Pin transitive dependencies to non-vulnerable versions (GHSA-m5vv-6r4h-3vj9 etc.).
+             These are pulled in transitively (e.g. via Microsoft.Data.SqlClient). -->
+        <PackageReference Include="Azure.Identity" Version="1.13.2" />
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/TownSuite.Web.Example/TownSuite.Web.Example.csproj
+++ b/TownSuite.Web.Example/TownSuite.Web.Example.csproj
@@ -17,11 +17,10 @@
         <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
         <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
         <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc" Version="5.5.0" />
-        <!-- Pin transitive dependencies to non-vulnerable versions (GHSA-m5vv-6r4h-3vj9 etc.).
-             These are pulled in transitively (e.g. via Microsoft.Data.SqlClient). -->
+        <!-- Pin transitive dependencies to non-vulnerable versions (GHSA-m5vv-6r4h-3vj9).
+             These are pulled in transitively via Microsoft.Data.SqlClient. -->
         <PackageReference Include="Azure.Identity" Version="1.13.2" />
         <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/TownSuite.Web.SSV3Adapter.Prometheus/SqlClientObserver.cs
+++ b/TownSuite.Web.SSV3Adapter.Prometheus/SqlClientObserver.cs
@@ -21,16 +21,20 @@ public sealed class SqlClientObserver : IObserver<DiagnosticListener>
 
     public SqlClientObserver(string prefix = "")
     {
+        // NOTE: the raw SQL CommandText is deliberately NOT used as a label. Doing so
+        // produces unbounded label cardinality (one permanent time series per distinct
+        // statement -> memory/scrape DoS) and exports SQL text (schema and any inline
+        // literal values) to the /metrics endpoint. Only low-cardinality labels are used.
         _sqlTotal = Metrics
             .CreateGauge($"{prefix}sql_commands_executed_total",
                 "Provides the count of sql commands sent to a database.",
-                new GaugeConfiguration { LabelNames = new[] { "commandtype", "commandtext", "server", "database" } });
+                new GaugeConfiguration { LabelNames = new[] { "commandtype", "server", "database" } });
 
         _sqlDuration = Metrics
             .CreateHistogram($"{prefix}sql_commands_duration_seconds",
                 "The duration of individual sql commands sent to a database.",
                 new HistogramConfiguration
-                    { LabelNames = new[] { "commandtype", "commandtext", "server", "database" } });
+                    { LabelNames = new[] { "commandtype", "server", "database" } });
     }
 
     void IObserver<DiagnosticListener>.OnNext(DiagnosticListener diagnosticListener)
@@ -90,11 +94,9 @@ public sealed class SqlClientObserver : IObserver<DiagnosticListener>
         var timeTakenSecs = _stopwatch.Value.ElapsedMilliseconds / 1000d;
 
         _sqlDuration.WithLabels(command.CommandType.ToString(),
-            command.CommandText,
             command.Connection?.DataSource ?? "",
             command.Connection?.Database ?? "").Observe(timeTakenSecs);
         _sqlTotal.WithLabels(command.CommandType.ToString(),
-            command.CommandText,
             command.Connection?.DataSource ?? "",
             command.Connection?.Database ?? "").Inc();
     }

--- a/TownSuite.Web.SSV3Adapter/ServiceStackFacade.cs
+++ b/TownSuite.Web.SSV3Adapter/ServiceStackFacade.cs
@@ -1,6 +1,11 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using TownSuite.Web.SSV3Adapter.Interfaces;
@@ -92,10 +97,27 @@ internal class ServiceStackAdapter
         var authorizationAttribute = await _ssHelper.GetAttributeAsync<IAuthorizationFilter>(serviceInfo.Service);
         if (authorizationAttribute != null)
         {
-            var context = _serviceProvider.GetService<AuthorizationFilterContext>();
+            var httpContext = _serviceProvider.GetService<IHttpContextAccessor>()?.HttpContext
+                ?? throw new InvalidOperationException(
+                    "An IHttpContextAccessor with an active HttpContext must be available to evaluate " +
+                    "IAuthorizationFilter attributes. Register it with services.AddHttpContextAccessor().");
 
-            // TODO: what to do here?
-            authorizationAttribute.OnAuthorization(context);
+            var actionContext = new ActionContext(httpContext, httpContext.GetRouteData(), new ActionDescriptor());
+            var authContext = new AuthorizationFilterContext(actionContext,
+                new List<IFilterMetadata> { authorizationAttribute });
+
+            authorizationAttribute.OnAuthorization(authContext);
+
+            // An authorization filter denies a request by assigning a short-circuit Result
+            // (e.g. UnauthorizedResult / ForbidResult). Honor it instead of silently
+            // continuing to construct and invoke the service.
+            if (authContext.Result != null)
+            {
+                var statusCode = (authContext.Result as IStatusCodeActionResult)?.StatusCode
+                                 ?? StatusCodes.Status403Forbidden;
+                _prom?.ExceptionTriggered();
+                return (statusCode, null);
+            }
         }
 
         var instance = await _ssHelper.ConstructServiceObjectAsync(serviceInfo.Service);
@@ -134,13 +156,13 @@ internal class ServiceStackAdapter
                 t = serviceInfo.Method.Invoke(instance, arguments.ToArray()) as Task;
                 await t.ConfigureAwait(false);
                 var response = t.GetType().GetProperty("Result").GetValue(t);
-                output = JsonConvert.SerializeObject(response);
+                output = JsonConvert.SerializeObject(response, _options.SerializerSettings);
                 return (200, output);
             }
 
             var val = await Task.FromResult(serviceInfo.Method.Invoke(instance, arguments.ToArray()));
             t = Task.FromResult(val);
-            output = JsonConvert.SerializeObject(val);
+            output = JsonConvert.SerializeObject(val, _options.SerializerSettings);
             return (200, output);
         }
         catch (Exception ex)
@@ -154,8 +176,8 @@ internal class ServiceStackAdapter
             else if (t != null)
             {
                 await t.ConfigureAwait(false);
-                output = JsonConvert.SerializeObject(t.GetType().GetProperty("Result").GetValue(t)
-                );
+                output = JsonConvert.SerializeObject(t.GetType().GetProperty("Result").GetValue(t),
+                    _options.SerializerSettings);
             }
             else
             {

--- a/TownSuite.Web.SSV3Adapter/ServiceStackV3FacadeOptions.cs
+++ b/TownSuite.Web.SSV3Adapter/ServiceStackV3FacadeOptions.cs
@@ -42,4 +42,10 @@ public class ServiceStackV3AdapterOptions
 
     public Func<ISSV3Prometheus>? Prometheus { get; set; } = null;
     public Func<Exception, ValueTask<(int statusCode, string? json)?>> OtherExceptionCallback { get; set; }
+
+    /// <summary>
+    ///     Maximum size (in bytes) of a request body accepted on the adapter route. Requests larger
+    ///     than this are rejected with 413 before the body is buffered into memory. Defaults to 30 MB.
+    /// </summary>
+    public long MaxRequestBodyBytes { get; set; } = 30 * 1024 * 1024;
 }

--- a/TownSuite.Web.SSV3Adapter/ServiceStackV3FacadeRouteExtensions.cs
+++ b/TownSuite.Web.SSV3Adapter/ServiceStackV3FacadeRouteExtensions.cs
@@ -75,18 +75,22 @@ public static class ServiceStackV3AdapterRouteExtensions
     /// </summary>
     private static async Task<(bool tooLarge, string value)> ReadBodyAsync(HttpContext context, long maxBytes)
     {
+        var token = context.RequestAborted;
+
         // Fast path: trust a declared Content-Length to reject oversized requests early.
         if (context.Request.ContentLength is long declared && declared > maxBytes)
         {
             return (true, string.Empty);
         }
 
-        using var reader = new StreamReader(context.Request.Body);
-        var buffer = new char[8192];
-        var sb = new StringBuilder();
+        // Count raw bytes (not decoded chars): a char count undercounts multibyte UTF-8 payloads
+        // and would let bodies exceed the configured byte limit.
+        var body = context.Request.Body;
+        var buffer = new byte[8192];
+        using var ms = new MemoryStream();
         long total = 0;
         int read;
-        while ((read = await reader.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        while ((read = await body.ReadAsync(buffer.AsMemory(0, buffer.Length), token)) > 0)
         {
             total += read;
             if (total > maxBytes)
@@ -94,10 +98,10 @@ public static class ServiceStackV3AdapterRouteExtensions
                 return (true, string.Empty);
             }
 
-            sb.Append(buffer, 0, read);
+            ms.Write(buffer, 0, read);
         }
 
-        return (false, sb.ToString());
+        return (false, Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length));
     }
 
 

--- a/TownSuite.Web.SSV3Adapter/ServiceStackV3FacadeRouteExtensions.cs
+++ b/TownSuite.Web.SSV3Adapter/ServiceStackV3FacadeRouteExtensions.cs
@@ -1,16 +1,39 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System.Text;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Newtonsoft.Json;
 
 namespace TownSuite.Web.SSV3Adapter;
 
 public static class ServiceStackV3AdapterRouteExtensions
 {
+    /// <summary>
+    ///     Registers the ServiceStack V3 adapter route.
+    /// </summary>
+    /// <remarks>
+    ///     Security: the host application is responsible for configuring a production exception
+    ///     handler (e.g. app.UseExceptionHandler) and for NOT enabling the developer exception page
+    ///     in production. Unhandled service exceptions are rethrown by the adapter, and whether a
+    ///     stack trace reaches the client is determined entirely by the host's exception handling.
+    /// </remarks>
     public static void UseServiceStackV3Adapter(
         this IApplicationBuilder applicationBuilder,
         ServiceStackV3AdapterOptions options,
         IServiceProvider serviceProvider)
     {
+        // Reject insecure deserialization configuration up-front. With TypeNameHandling other than
+        // None, attacker-controlled request bodies can instantiate arbitrary types via $type
+        // directives (gadget/RCE risk). Request bodies are fully untrusted, so fail closed here.
+        if (options.SerializerSettings != null &&
+            options.SerializerSettings.TypeNameHandling != TypeNameHandling.None)
+        {
+            throw new InvalidOperationException(
+                "ServiceStackV3AdapterOptions.SerializerSettings.TypeNameHandling must be " +
+                "TypeNameHandling.None. Any other value allows insecure deserialization of " +
+                "attacker-controlled request bodies.");
+        }
+
         var builder = new RouteBuilder(applicationBuilder);
 
         // use middlewares to configure a route
@@ -22,10 +45,11 @@ public static class ServiceStackV3AdapterRouteExtensions
 
                 string path = context.Request.Path;
 
-                string value;
-                using (var reader = new StreamReader(context.Request.Body))
+                var (tooLarge, value) = await ReadBodyAsync(context, options.MaxRequestBodyBytes);
+                if (tooLarge)
                 {
-                    value = await reader.ReadToEndAsync();
+                    context.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
+                    return;
                 }
 
                 var method = context.Request.Method;
@@ -45,6 +69,48 @@ public static class ServiceStackV3AdapterRouteExtensions
     }
 
 
+    /// <summary>
+    ///     Reads the request body into a string, rejecting bodies larger than <paramref name="maxBytes"/>
+    ///     without buffering the whole (potentially huge) payload into memory first.
+    /// </summary>
+    private static async Task<(bool tooLarge, string value)> ReadBodyAsync(HttpContext context, long maxBytes)
+    {
+        // Fast path: trust a declared Content-Length to reject oversized requests early.
+        if (context.Request.ContentLength is long declared && declared > maxBytes)
+        {
+            return (true, string.Empty);
+        }
+
+        using var reader = new StreamReader(context.Request.Body);
+        var buffer = new char[8192];
+        var sb = new StringBuilder();
+        long total = 0;
+        int read;
+        while ((read = await reader.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        {
+            total += read;
+            if (total > maxBytes)
+            {
+                return (true, string.Empty);
+            }
+
+            sb.Append(buffer, 0, read);
+        }
+
+        return (false, sb.ToString());
+    }
+
+
+    /// <summary>
+    ///     Registers a route that serves a generated OpenAPI (swagger) document describing every
+    ///     discovered service.
+    /// </summary>
+    /// <remarks>
+    ///     Security: this document enumerates the full internal service/DTO surface and is served
+    ///     without authentication. Do not register it in production unless the route is protected by
+    ///     an authorization policy or network restriction. See the example host, which only registers
+    ///     it in the Development environment.
+    /// </remarks>
     public static void UseServiceStackV3AdapterSwagger(
         this IApplicationBuilder applicationBuilder,
         ServiceStackV3AdapterOptions options, string description = "Description",

--- a/TownSuite.Web.SSV3Adapter/SsHelper.cs
+++ b/TownSuite.Web.SSV3Adapter/SsHelper.cs
@@ -8,11 +8,16 @@ namespace TownSuite.Web.SSV3Adapter;
 
 internal class SsHelper
 {
+    // These caches are static (shared across all adapter instances/configurations in the
+    // process). To avoid one adapter's resolution leaking onto another adapter's route, every
+    // cache key is prefixed with a signature of the owning options (route + service base types
+    // + searched assemblies). See GetOptionsSignature.
     private static readonly ConcurrentDictionary<string, (Type Service, MethodInfo Method, Type DtoType)> ServiceMap =
         new();
 
 
-    private static readonly ConcurrentDictionary<Type, (Type Service, MethodInfo Method, Type DtoType)>
+    private static readonly ConcurrentDictionary<string,
+            ConcurrentDictionary<Type, (Type Service, MethodInfo Method, Type DtoType)>>
         SwaggerServiceMap
             = new();
 
@@ -68,8 +73,10 @@ internal class SsHelper
     public (Type Service, MethodInfo Method, Type DtoType)?
         GetService(string requestName)
     {
-        // TODO: ADD CACHE
-        if (ServiceMap.ContainsKey(requestName)) return ServiceMap[requestName];
+        // Cache key is scoped to this adapter's configuration so a service resolved under one
+        // adapter is never served on another adapter's route.
+        var cacheKey = $"{GetOptionsSignature(_options)}|{requestName}";
+        if (ServiceMap.TryGetValue(cacheKey, out var cached)) return cached;
 
         foreach (var asm in _options.SearchAssemblies)
         {
@@ -79,12 +86,9 @@ internal class SsHelper
                 var methodInfo = GetMethod(requestName, service);
                 if (methodInfo.method != null)
                 {
-                    // key, value, func<TKey, TValue, TValue>
-                    ServiceMap.AddOrUpdate(requestName,
-                        (service, methodInfo.method, methodInfo.dtoType),
-                        (s, m) => { return (service, methodInfo.method, methodInfo.dtoType); });
-
-                    return (service, methodInfo.method, methodInfo.dtoType);
+                    var entry = (service, methodInfo.method, methodInfo.dtoType);
+                    ServiceMap[cacheKey] = entry;
+                    return entry;
                 }
             }
 
@@ -94,10 +98,31 @@ internal class SsHelper
         return null;
     }
 
+    /// <summary>
+    ///     Builds a stable signature of the supplied options so static caches can be partitioned
+    ///     per adapter configuration. Includes the route, the allowed service base types, and the
+    ///     searched assemblies - the inputs that determine which services an adapter may resolve.
+    /// </summary>
+    internal static string GetOptionsSignature(ServiceStackV3AdapterOptions options)
+    {
+        var assemblies = string.Join(",",
+            (options.SearchAssemblies ?? Array.Empty<Assembly>())
+            .Select(a => a.FullName).OrderBy(x => x, StringComparer.Ordinal));
+        var serviceTypes = string.Join(",",
+            (options.ServiceTypes ?? Array.Empty<Type>())
+            .Select(t => t.FullName).OrderBy(x => x, StringComparer.Ordinal));
+        return $"{options.RoutePath}|{assemblies}|{serviceTypes}";
+    }
+
     public ConcurrentDictionary<Type, (Type Service, MethodInfo Method, Type DtoType)>
         GetAllServices()
     {
-        if (SwaggerServiceMap.Any()) return SwaggerServiceMap;
+        var signature = GetOptionsSignature(_options);
+        if (SwaggerServiceMap.TryGetValue(signature, out var existing) && existing.Any())
+            return existing;
+
+        var map = SwaggerServiceMap.GetOrAdd(signature,
+            _ => new ConcurrentDictionary<Type, (Type Service, MethodInfo Method, Type DtoType)>());
 
         var types = PermissiveLoadAssemblies();
 
@@ -107,13 +132,13 @@ internal class SsHelper
             var methodInfo = GetMethod("", service);
             if (methodInfo.method != null)
                 // key, value, func<TKey, TValue, TValue>
-                SwaggerServiceMap.AddOrUpdate(methodInfo.method.DeclaringType,
+                map.AddOrUpdate(methodInfo.method.DeclaringType,
                     (service, methodInfo.method, methodInfo.dtoType),
                     (s, m) => { return (service, methodInfo.method, methodInfo.dtoType); });
         }
 
         // continue on and try the next dll
-        return SwaggerServiceMap;
+        return map;
     }
 
     private List<Type> PermissiveLoadAssemblies()
@@ -198,8 +223,14 @@ internal class SsHelper
             if (individualParameter == requestName ||
                 string.IsNullOrWhiteSpace(requestName))
             {
-                method = mi;
-                paramType = parameters.FirstOrDefault().ParameterType;
+                // Prefer a recognized action-verb handler (Any/AnyAsync/Get/Post). This makes
+                // selection deterministic and prevents an unintended same-signature helper method
+                // from shadowing the real endpoint when several methods share the parameter type.
+                if (method == null || (!IsActionVerb(method.Name) && IsActionVerb(mi.Name)))
+                {
+                    method = mi;
+                    paramType = parameters.FirstOrDefault().ParameterType;
+                }
             }
         }
 
@@ -270,6 +301,12 @@ internal class SsHelper
     {
         foreach (var mi in serviceType.GetMethods(BindingFlags.Public | BindingFlags.Instance).OrderBy(p => p.Name))
         {
+            // Never treat methods inherited from System.Object (Equals, etc.) as dispatchable
+            // endpoints. object.Equals(object) has a reference-type parameter and would otherwise
+            // be remotely invocable via /.../Object.
+            if (mi.DeclaringType == typeof(object))
+                continue;
+
             var parameters = mi.GetParameters();
 
             if (mi.IsGenericMethod || parameters.Length <= 0 || parameters.Length > 2)
@@ -279,9 +316,7 @@ internal class SsHelper
             if (paramType.IsValueType || paramType == typeof(string))
                 continue;
 
-            var actionName = mi.Name.ToUpper();
-            if (actionName != "ANY" && actionName != "ANYASYNC" &&
-                actionName != "POST" && actionName != "GET")
+            if (!IsActionVerb(mi.Name))
             {
                 if (string.Equals(paramType.Name, requestName, StringComparison.InvariantCultureIgnoreCase))
                     yield return mi;
@@ -291,5 +326,11 @@ internal class SsHelper
 
             yield return mi;
         }
+    }
+
+    private static bool IsActionVerb(string methodName)
+    {
+        var name = methodName.ToUpperInvariant();
+        return name == "ANY" || name == "ANYASYNC" || name == "POST" || name == "GET";
     }
 }

--- a/TownSuite.Web.SSV3Adapter/Swagger.cs
+++ b/TownSuite.Web.SSV3Adapter/Swagger.cs
@@ -43,13 +43,17 @@ internal class Swagger
 
     public async Task<(int statusCode, string json)> Generate(string host)
     {
-        var cacheKey = $"{SsHelper.GetOptionsSignature(_options)}|{_options.SwaggerPath}|{_title}|{_version}|{_description}";
+        // Cache is only consulted in non-DEBUG builds; only populate it there too so DEBUG/test
+        // runs don't accumulate entries that are never read.
 #if !DEBUG
+        var cacheKey = $"{SsHelper.GetOptionsSignature(_options)}|{_options.SwaggerPath}|{_title}|{_version}|{_description}";
         if (JsonCache.TryGetValue(cacheKey, out var cached) && !string.IsNullOrWhiteSpace(cached))
             return (200, cached);
 #endif
         var json = await PreGenerateJson(host);
+#if !DEBUG
         JsonCache[cacheKey] = json;
+#endif
 
         return (200, json ?? "");
     }

--- a/TownSuite.Web.SSV3Adapter/Swagger.cs
+++ b/TownSuite.Web.SSV3Adapter/Swagger.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -13,7 +14,9 @@ namespace TownSuite.Web.SSV3Adapter;
 
 internal class Swagger
 {
-    private static string? jsonCached;
+    // Keyed by a per-configuration signature so two swagger endpoints in the same process
+    // (different routes/assemblies/metadata) never serve each other's generated document.
+    private static readonly ConcurrentDictionary<string, string> JsonCache = new();
     private readonly string _description;
     private readonly ServiceStackV3AdapterOptions _options;
     private readonly SsHelper _ssHelper;
@@ -40,18 +43,21 @@ internal class Swagger
 
     public async Task<(int statusCode, string json)> Generate(string host)
     {
+        var cacheKey = $"{SsHelper.GetOptionsSignature(_options)}|{_options.SwaggerPath}|{_title}|{_version}|{_description}";
 #if !DEBUG
-        if (!string.IsNullOrWhiteSpace(jsonCached)) return (200, jsonCached ?? "");
+        if (JsonCache.TryGetValue(cacheKey, out var cached) && !string.IsNullOrWhiteSpace(cached))
+            return (200, cached);
 #endif
-        await PreGenerateJson(host);
+        var json = await PreGenerateJson(host);
+        JsonCache[cacheKey] = json;
 
-        return (200, jsonCached ?? "");
+        return (200, json ?? "");
     }
 
     /// <summary>
     ///     Used to pre
     /// </summary>
-    private async Task PreGenerateJson(string host)
+    private async Task<string> PreGenerateJson(string host)
     {
         var serviceInfo = _ssHelper.GetAllServices();
     //    var sortedServiceInfo =
@@ -236,7 +242,7 @@ internal class Swagger
 
         var sb = new StringBuilder();
         swaggerDoc.SerializeAsV3(new OpenApiJsonWriter(new StringWriter(sb)));
-        jsonCached = sb.ToString();
+        return sb.ToString();
     }
 
     private static string GetSchemaType(Type type)

--- a/TownSuite.Web.Tests/AuthorizationFilterTest.cs
+++ b/TownSuite.Web.Tests/AuthorizationFilterTest.cs
@@ -1,0 +1,110 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using TownSuite.Web.SSV3Adapter;
+
+namespace TownSuite.Web.Tests;
+
+[TestFixture]
+public class AuthorizationFilterTest
+{
+    private static ServiceStackAdapter BuildAdapter()
+    {
+        var options = new ServiceStackV3AdapterOptions(new[] { typeof(AuthFilterTestBase) })
+        {
+            RoutePath = "/authtest/{name}",
+            SearchAssemblies = new[] { typeof(AuthorizationFilterTest).Assembly },
+            SerializerSettings = new JsonSerializerSettings()
+        };
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IHttpContextAccessor>(
+            new FakeHttpContextAccessor { HttpContext = new DefaultHttpContext() });
+        var serviceProvider = services.BuildServiceProvider();
+
+        return new ServiceStackAdapter(options, serviceProvider);
+    }
+
+    [Test]
+    public async Task DenyingAuthorizationFilter_ShortCircuits_WithFilterStatusCode()
+    {
+        var adapter = BuildAdapter();
+
+        var result = await adapter.Post("/authtest/AuthDenyRequest", "{}", "POST");
+
+        // The filter sets UnauthorizedResult (401); the adapter must honor it and never invoke the service.
+        Assert.That(result.statusCode, Is.EqualTo(401));
+    }
+
+    [Test]
+    public async Task NonDenyingAuthorizationFilter_AllowsRequest_ToReachService()
+    {
+        var adapter = BuildAdapter();
+
+        var result = await adapter.Post("/authtest/AuthAllowRequest", "{}", "POST");
+
+        Assert.That(result.statusCode, Is.EqualTo(200));
+    }
+}
+
+public class AuthFilterTestBase
+{
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class DenyAuthorizationAttribute : Attribute, IAuthorizationFilter
+{
+    public void OnAuthorization(AuthorizationFilterContext context)
+    {
+        context.Result = new UnauthorizedResult();
+    }
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class AllowAuthorizationAttribute : Attribute, IAuthorizationFilter
+{
+    public void OnAuthorization(AuthorizationFilterContext context)
+    {
+        // Intentionally does not set context.Result -> request is allowed to proceed.
+    }
+}
+
+public class AuthDenyRequest
+{
+}
+
+public class AuthAllowRequest
+{
+}
+
+public class AuthResponse
+{
+    public bool Reached { get; set; }
+}
+
+[DenyAuthorization]
+public class AuthDenyService : AuthFilterTestBase
+{
+    public AuthResponse Any(AuthDenyRequest request)
+    {
+        return new AuthResponse { Reached = true };
+    }
+}
+
+[AllowAuthorization]
+public class AuthAllowService : AuthFilterTestBase
+{
+    public AuthResponse Any(AuthAllowRequest request)
+    {
+        return new AuthResponse { Reached = true };
+    }
+}
+
+internal class FakeHttpContextAccessor : IHttpContextAccessor
+{
+    public HttpContext? HttpContext { get; set; }
+}

--- a/TownSuite.Web.Tests/SwaggerTest.cs
+++ b/TownSuite.Web.Tests/SwaggerTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using TownSuite.Web.SSV3Adapter;
 
 namespace TownSuite.Web.Tests;
@@ -15,7 +15,7 @@ public class SwaggerTest
         var swag = new Swagger(options, serviceProvider,
             "description", "title", "v1");
         var results = await swag.Generate("localhost");
-        
+
         Assert.That(results.json,
             Is.EqualTo(
                 @"{
@@ -44,6 +44,55 @@ public class SwaggerTest
               ""application/json"": {
                 ""schema"": {
                   ""$ref"": ""#/components/schemas/TownSuite.Web.Example.ServiceStackExample.Example2Response""
+                }
+              }
+            }
+          },
+          ""299"": {
+            ""description"": ""Partial Success""
+          },
+          ""400"": {
+            ""description"": ""Bad Request""
+          },
+          ""401"": {
+            ""description"": ""Unauthorized""
+          },
+          ""403"": {
+            ""description"": ""Forbidden""
+          },
+          ""429"": {
+            ""description"": ""Too Many Requests""
+          },
+          ""500"": {
+            ""description"": ""Internal Server Error""
+          },
+          ""502"": {
+            ""description"": ""Bad Gateway""
+          },
+          ""504"": {
+            ""description"": ""Gateway Timeout""
+          }
+        }
+      }
+    },
+    ""/service/json/syncreply/{name}/ExampleAsyncClass"": {
+      ""post"": {
+        ""requestBody"": {
+          ""content"": {
+            ""application/json"": {
+              ""schema"": {
+                ""$ref"": ""#/components/schemas/TownSuite.Web.Example.ServiceStackExample.ExampleAsyncClass""
+              }
+            }
+          }
+        },
+        ""responses"": {
+          ""200"": {
+            ""description"": ""Success"",
+            ""content"": {
+              ""application/json"": {
+                ""schema"": {
+                  ""$ref"": ""#/components/schemas/TownSuite.Web.Example.ServiceStackExample.ExampleAsyncClassResponse""
                 }
               }
             }
@@ -474,6 +523,26 @@ public class SwaggerTest
           },
           ""LastName"": {
             ""type"": ""string""
+          }
+        }
+      },
+      ""TownSuite.Web.Example.ServiceStackExample.ExampleAsyncClass"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""DelayMilliseconds"": {
+            ""type"": ""integer""
+          },
+          ""Message"": {
+            ""type"": ""string""
+          }
+        },
+        ""description"": """"
+      },
+      ""TownSuite.Web.Example.ServiceStackExample.ExampleAsyncClassResponse"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""DidCancelWithResponse"": {
+            ""type"": ""boolean""
           }
         }
       },

--- a/TownSuite.Web.Tests/TownSuite.Web.Tests.csproj
+++ b/TownSuite.Web.Tests/TownSuite.Web.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '3.4'
 
 services:
+  # Local-dev SA password is supplied via the SQL_SA_PASSWORD environment variable
+  # (see .env.example). No credentials are hardcoded in source control.
   townsuite.web.example:
     image: ${DOCKER_REGISTRY-}townsuiteweb
     build:
@@ -8,21 +10,25 @@ services:
       dockerfile: TownSuite.Web.Example/Dockerfile
     ports:
         - "32080:80"
+    environment:
+        ConnectionStrings__TestDb: "Server=sql_service;Database=test_data;User Id=SA;Password=${SQL_SA_PASSWORD};trustServerCertificate=true"
   sql_service:
     image: "mcr.microsoft.com/mssql/server:2019-latest"
-    ports:  
+    ports:
         - "31033:1433"
     environment:
-        SA_PASSWORD: "ThePassword321&"
+        SA_PASSWORD: "${SQL_SA_PASSWORD}"
         ACCEPT_EULA: "Y"
   sql_tools:
     image: "mcr.microsoft.com/mssql-tools"
     depends_on:
         - sql_service
+    environment:
+        SQL_SA_PASSWORD: "${SQL_SA_PASSWORD}"
     command: >
         sh -c "sleep 25s &&
-        /opt/mssql-tools/bin/sqlcmd -U SA -P \"ThePassword321&\" -S sql_service -d master -Q \"CREATE DATABASE test_data;\" &&
-        /opt/mssql-tools/bin/sqlcmd -U SA -P \"ThePassword321&\" -S sql_service -d test_data -Q \"CREATE TABLE test_table (test_column int, test_column2 varchar(255));\" &&
-        /opt/mssql-tools/bin/sqlcmd -U SA -P \"ThePassword321&\" -S sql_service -d test_data -Q \"INSERT INTO test_table values(1, 'hello');\"
+        /opt/mssql-tools/bin/sqlcmd -U SA -P \"$$SQL_SA_PASSWORD\" -S sql_service -d master -Q \"CREATE DATABASE test_data;\" &&
+        /opt/mssql-tools/bin/sqlcmd -U SA -P \"$$SQL_SA_PASSWORD\" -S sql_service -d test_data -Q \"CREATE TABLE test_table (test_column int, test_column2 varchar(255));\" &&
+        /opt/mssql-tools/bin/sqlcmd -U SA -P \"$$SQL_SA_PASSWORD\" -S sql_service -d test_data -Q \"INSERT INTO test_table values(1, 'hello');\"
         "
 


### PR DESCRIPTION
This pull request introduces several improvements and security enhancements across the ServiceStack V3 adapter, the example application, and the Prometheus SQL client observer. The changes focus on securing deserialization, limiting request body size, improving authorization handling, updating dependencies, and enhancing metrics safety.

**ServiceStack V3 Adapter Security and Robustness:**

* Enforces safe JSON deserialization by rejecting any `SerializerSettings.TypeNameHandling` value other than `None`, preventing insecure deserialization of attacker-controlled request bodies.
* Adds a configurable `MaxRequestBodyBytes` (default 30 MB) to `ServiceStackV3AdapterOptions` and implements logic to reject oversized request bodies with a 413 status code before buffering, mitigating DoS risks. [[1]](diffhunk://#diff-e8b607d229e49bbf0a16a20dbaea1802a8c5576195729d363e676357f2b6d884R45-R50) [[2]](diffhunk://#diff-f18dc99e3058317c1aa3cf7ccd72b00e8b6a2d807b62f02c7ec673fd41d96002L25-R52) [[3]](diffhunk://#diff-f18dc99e3058317c1aa3cf7ccd72b00e8b6a2d807b62f02c7ec673fd41d96002R72-R113)
* Authorization filters are now properly respected: if an authorization filter returns a result (e.g., Unauthorized), the adapter short-circuits and returns the correct status code instead of invoking the service.
* Ensures that custom `JsonSerializerSettings` provided in options are used consistently for all serialization responses, not just the defaults. [[1]](diffhunk://#diff-e436051b32469d17f5ebb63e08c887390c95aef9b910ca82c7437e498649e097L137-R165) [[2]](diffhunk://#diff-e436051b32469d17f5ebb63e08c887390c95aef9b910ca82c7437e498649e097L157-R180)
* Improves internal caching to avoid leaking service resolution across adapter configurations by scoping cache keys to the options signature. [[1]](diffhunk://#diff-9ba686e8c3960cde94853051fe329cc55cdc0040cca6c33802785e811d785687R11-R20) [[2]](diffhunk://#diff-9ba686e8c3960cde94853051fe329cc55cdc0040cca6c33802785e811d785687L71-R79) [[3]](diffhunk://#diff-9ba686e8c3960cde94853051fe329cc55cdc0040cca6c33802785e811d785687L82-R91)

**Prometheus SQL Metrics Safety:**

* Removes the use of raw SQL `CommandText` as a Prometheus label to prevent unbounded cardinality and accidental data exposure, using only low-cardinality labels (`commandtype`, `server`, `database`). [[1]](diffhunk://#diff-75a098d39b5c460af57f92528d4c23e581cc486e9fad075408a12b8274a2e5fbR24-R37) [[2]](diffhunk://#diff-75a098d39b5c460af57f92528d4c23e581cc486e9fad075408a12b8274a2e5fbL93-L97)

**Example Application Improvements:**

* Upgrades target framework to `.NET 10.0` and updates several dependencies, including patching transitive dependencies for security vulnerabilities. [[1]](diffhunk://#diff-0ab6f8435881803fe382e54f56341b0d020e3ff1355a52696f1673eb51f8218dL4-R4) [[2]](diffhunk://#diff-0ab6f8435881803fe382e54f56341b0d020e3ff1355a52696f1673eb51f8218dL13-R24)
* Restricts the Swagger/OpenAPI endpoint to development environments only, with clear documentation on the security implications of exposing internal service surfaces. [[1]](diffhunk://#diff-233bccab061e276a68a507c727d1270523f045597df469c124a80f8252aa1873R150-R154) [[2]](diffhunk://#diff-233bccab061e276a68a507c727d1270523f045597df469c124a80f8252aa1873R169)
* The example data profiling service now skips database calls if the connection string is not configured, improving robustness for non-DB environments.
* Adds an example `.env` file for local development, clarifying that credentials should not be reused or committed.

**Serialization and DTO Handling:**

* The `AllPropertiesResolver` now surfaces properties marked `[JsonIgnore]` for backward compatibility in output, but ensures they are never writable from input, preventing overposting/mass-assignment vulnerabilities.

**Versioning:**

* Bumps the assembly version to `26.1.0` in preparation for release.